### PR TITLE
remove python version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,6 @@ setup(
     long_description_content_type="text/markdown",
     author="mbd ds team",
     author_email="na@mbd.xyz",
-    python_requires="~=3.10",
     include_package_data=True,
     packages=find_namespace_packages(include=["mbd_core", "mbd_core.*"]),
     package_data={"mbd_core.enrich.labelling": ["config.json"]},


### PR DESCRIPTION
<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will post its summary as a comment. -->
### Remove `python_requires="~=3.10"` from `setup()` in [setup.py](https://github.com/ZKAI-Network/mbd-core/pull/25/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7) to drop the Python version constraint
Delete the `python_requires` argument from the `setup()` call in [setup.py](https://github.com/ZKAI-Network/mbd-core/pull/25/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7).

#### 📍Where to Start
Start with the `setup()` configuration in [setup.py](https://github.com/ZKAI-Network/mbd-core/pull/25/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7).

----
<!-- Macroscope's review summary starts here -->

<a href="https://app.macroscope.com">Macroscope</a> summarized da209da.
<!-- Macroscope's review summary ends here -->

<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->